### PR TITLE
Fixed README image integration

### DIFF
--- a/EventGrid/README.md
+++ b/EventGrid/README.md
@@ -131,7 +131,7 @@ Integrate Logic App with IoTHub via Event Grid
 
 Click on Event Subscription
 
-![Integrated with IoTHub](images/14_empty_event_subscription.png "")
+![Integrated with IoTHub](images/14_empty_event_subscription.png)
 
 Copy the URL from previous steps into Subscriber Endpoint and click create
 


### PR DESCRIPTION
Somehow the image 14 is not correctly rendered on the website: https://azure-samples.github.io/azureiotlabs/EventGrid/ I removed the empty parentheses in an attempt to fix it.

## Purpose
Fixing an image reference in README for https://azure-samples.github.io/azureiotlabs/EventGrid/

## Does this introduce a breaking change?
[ ] Yes
[x] No
```

## Pull Request Type
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

## What to Check
If you include the change, the image 14 `![Integrated with IoTHub](images/14_empty_event_subscription.png “”)` on https://azure-samples.github.io/azureiotlabs/EventGrid/ should be visible. Currently it shows: 

Click on Event Subscription

![Integrated with IoTHub](images/14_empty_event_subscription.png “”)

Copy the URL from previous steps into Subscriber Endpoint and click create 